### PR TITLE
Fix nixpacks start command: Use absolute paths and PYTHONPATH

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -14,4 +14,4 @@ cmds = [
 ]
 
 [start]
-cmd = 'nelson-gpt-backend/venv/bin/python nelson-gpt-backend/src/main.py'
+cmd = 'PYTHONPATH=/app/nelson-gpt-backend /app/nelson-gpt-backend/venv/bin/python /app/nelson-gpt-backend/src/main.py'


### PR DESCRIPTION
The container was failing to start with 'cd executable not found' error. Fixed by:
- Using absolute paths for Python executable and main.py
- Setting PYTHONPATH environment variable for proper module resolution
- Avoiding cd command in start command which was causing the error

This should resolve the container startup issue.